### PR TITLE
Avoid notice for missing captions

### DIFF
--- a/src/services/Media.php
+++ b/src/services/Media.php
@@ -117,7 +117,7 @@ class Media extends Component
 
         foreach ($data['data'] as $media) {
             $model = new MediaModel([
-                'caption' => $media['caption'],
+                'caption' => $media['caption'] ?? '',
                 'id' => $media['id'],
                 'mediaType' => $media['media_type'],
                 'mediaUrl' => $media['media_url'],


### PR DESCRIPTION
It seems the media arrays from the Instagram API are sometimes missing a caption, it throws a notice. This PR fixes it.